### PR TITLE
[COOK-2584] Add client-side result cache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ of interest. For example, you can execute a search to return just the
 name and IP addresses of the nodes in your infrastructure rather than
 receiving an array of complete node objects and post-processing them.
 
+Finally, both the `search` and `partial_search` methods allow you to
+cache results to avoid repetitive queries for the same search terms.
+
 Install
 =======
 
@@ -42,6 +45,14 @@ choosing. Consider the following example:
 In the example above, two attributes will be extracted (on the
 server) from the nodes that match the search query. The result will
 be a simple hash with keys 'name'  and 'ip'.
+
+The `:cache` option allows you to retrieve cached search results if available.
+If an identical query was already issued during the current Chef run, its
+results will be immediately returned, thereby avoiding an unnecessary
+round-trip to the server.  For example:
+
+   partial_search(:node, 'role:web', :cache => true,
+                  :keys => ... )
 
 Notes
 =====

--- a/libraries/partial_search.rb
+++ b/libraries/partial_search.rb
@@ -32,10 +32,9 @@ class Chef
 
     attr_accessor :rest
 
-    @@cache = {}
-
     def initialize(url=nil)
       @rest = ::Chef::REST.new(url || ::Chef::Config[:search_url])
+      @cache = node.run_state["chef_partial_search_cache"] ||= {}
     end
 
     # Search Solr for objects of a given type, for a given query. If you give
@@ -87,13 +86,13 @@ class Chef
       end
 
       def cache_store(query_string, keys, val)
-        @@cache[query_string] ||= {}
-        @@cache[query_string][keys] ||= val
+        @cache[query_string] ||= {}
+        @cache[query_string][keys] ||= val
       end
 
       def cache_fetch(query_string, keys={})
-        if @@cache[query_string]
-          @@cache[query_string][keys]
+        if @cache[query_string]
+          @cache[query_string][keys]
         end
       end
   end

--- a/libraries/partial_search.rb
+++ b/libraries/partial_search.rb
@@ -32,6 +32,8 @@ class Chef
 
     attr_accessor :rest
 
+    @@cache = {}
+
     def initialize(url=nil)
       @rest = ::Chef::REST.new(url || ::Chef::Config[:search_url])
     end
@@ -46,11 +48,14 @@ class Chef
       rows = args.include?(:rows) ? args[:rows] : 1000
       query_string = "search/#{type}?q=#{escape(query)}&sort=#{escape(sort)}&start=#{escape(start)}&rows=#{escape(rows)}"
       if args[:keys]
-        response = @rest.post_rest(query_string, args[:keys])
+        response = args[:cache] && @@cache[query_string] ? @@cache[query_string] : @rest.post_rest(query_string, args[:keys])
         response_rows = response['rows'].map { |row| row['data'] }
       else
-        response = @rest.get_rest(query_string)
+        response = args[:cache] && @@cache[query_string] ? @@cache[query_string] : @rest.get_rest(query_string)
         response_rows = response['rows']
+      end
+      if args[:cache]
+        @@cache[query_string] ||= response
       end
       if block
         response_rows.each { |o| block.call(o) unless o.nil?}
@@ -62,7 +67,7 @@ class Chef
             :start => nstart,
             :rows => rows
           }
-          search(type, query, args_hash, &block)  
+          search(type, query, args_hash, &block)
         end
         true
       else

--- a/libraries/partial_search.rb
+++ b/libraries/partial_search.rb
@@ -48,14 +48,16 @@ class Chef
       rows = args.include?(:rows) ? args[:rows] : 1000
       query_string = "search/#{type}?q=#{escape(query)}&sort=#{escape(sort)}&start=#{escape(start)}&rows=#{escape(rows)}"
       if args[:keys]
-        response = args[:cache] && @@cache[query_string] ? @@cache[query_string] : @rest.post_rest(query_string, args[:keys])
+        response = args[:cache] ? cache_fetch(query_string, args[:keys]) : nil
+        response ||= @rest.post_rest(query_string, args[:keys])
         response_rows = response['rows'].map { |row| row['data'] }
       else
-        response = args[:cache] && @@cache[query_string] ? @@cache[query_string] : @rest.get_rest(query_string)
+        response = args[:cache] ? cache_fetch(query_string) : nil
+        response ||= @rest.get_rest(query_string)
         response_rows = response['rows']
       end
       if args[:cache]
-        @@cache[query_string] ||= response
+        cache_store(query_string, args[:keys], response)
       end
       if block
         response_rows.each { |o| block.call(o) unless o.nil?}
@@ -82,6 +84,17 @@ class Chef
     private
       def escape(s)
         s && URI.escape(s.to_s)
+      end
+
+      def cache_store(query_string, keys, val)
+        @@cache[query_string] ||= {}
+        @@cache[query_string][keys] ||= val
+      end
+
+      def cache_fetch(query_string, keys={})
+        if @@cache[query_string]
+          @@cache[query_string][keys]
+        end
       end
   end
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2584

Added support for a new option to the `partial_search` and `search` methods called `:cache`.

If set to a non-`nil` or non-`false` value, if will:
1. Retrieve the search result from the cache (if available), and avoid the querying the server; and
2. Store the result in the cache.

Updated `README.md` file to suit.

Licensed under the same terms as partial_search itself.
